### PR TITLE
added -d/-p options to vmatch

### DIFF
--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -185,7 +185,10 @@ void VmatchAligner::do_alignment(const string& index_name, const string& type, i
 		  else
 			  param_list += " -" + it->first + " " + it->second;
 	}
-	string cmd = "vmatch " + align_type + " -q " + reads_file + " -l " + int2str(match_length) + " " + e_option + " " + param_list + " -showdesc 0 -nodist -noevalue -noscore -noidentity " + index_name + " | awk '{print $1,$2,$3,$4,$5,$6}' | uniq -f5 > " + output_file;
+	string cmd = "vmatch " + align_type + " -q " + reads_file + " -d" + " -l " + int2str(match_length) + " " + e_option + " " + param_list + " -showdesc 0 -nodist -noevalue -noscore -noidentity " + index_name + " | awk '{print $1,$2,$3,$4,$5,$6}' | uniq -f5 > " + output_file;
+	logger->debug(cmd);
+	run_shell_command(cmd);
+	       cmd = "vmatch " + align_type + " -q " + reads_file + " -p" + " -l " + int2str(match_length) + " " + e_option + " " + param_list + " -showdesc 0 -nodist -noevalue -noscore -noidentity " + index_name + " | awk '{print $1,$2,$3,$4,$5,$6}' | uniq -f5 >> " + output_file;
 	logger->debug(cmd);
 	run_shell_command(cmd);
 }


### PR DESCRIPTION
vmatch by default only finds direct matches (-d option)

this code modification explicitly looks for reverse strand matches (-p option) as well

for paired-end reads maybe the previous implementation was sufficient (and faster) but conceptually the approach was odd - there are definitely scenarios when we want the reverse matches to be found